### PR TITLE
Change branch "master" to "main"

### DIFF
--- a/screenshot.js
+++ b/screenshot.js
@@ -2,7 +2,7 @@ var respecConfig = {
   group: "webrtc",
   github: {
     repoURL: "https://github.com/eladalon1983/mediacapture-screenshot/",
-    branch: "master",
+    branch: "main",
   },
   editors: [
     {


### PR DESCRIPTION
The link for "commit history" on the specification page leads to 404, as it tries to link to the branch `master`, so this seems like a logical fix to have it link to `main` since that is the branch name now.

(this is by no means an important fix, but I wanted to show interest in the proposal, so figured this might be a better way than a "thumbs up"-comment somewhere 🤷 )